### PR TITLE
use calldata instead of memory

### DIFF
--- a/packages/hardhat/contracts/Greeter.sol
+++ b/packages/hardhat/contracts/Greeter.sol
@@ -17,7 +17,7 @@ contract Greeter {
         return greeting;
     }
 
-    function setGreeting(string memory _greeting) external {
+    function setGreeting(string calldata _greeting) external {
         console.log("Changing greeting from '%s' to '%s'", greeting, _greeting);
         greeting = _greeting;
         emit newGreeting(_greeting, msg.sender);


### PR DESCRIPTION
The param _greeting will be not updated in setGreeting, so I used calldata instead of memory.

https://ethereum.stackexchange.com/questions/74442/when-should-i-use-calldata-and-when-should-i-use-memory