### PR TITLE
extend balance page functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ If you improve the user interface or create new components that you think might 
 
 We will happily compensate you for contributions. Anywhere between 5 and 50 cUSD (or more) depending on the work. This is dependent on the work that is done and is ultimately up to the discretion of the Celo Foundation developer relations team.
 
-You can view the associated bounty on Gitcoin [here](https://gitcoin.co/issue/celo-org/celo-progressive-dapp-starter/2/100027610).
+You can view the associated bounty on Gitcoin [here](https://gitcoin.co/issue/celo-org/celo-progressive-dapp-starter/17/100028587).
 
 ## How to Contribute a new dApp
 

--- a/packages/react-app/components/AccountInfo.tsx
+++ b/packages/react-app/components/AccountInfo.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { Divider, Grid, Typography, Link } from "@mui/material";
+import { Divider, Grid, Typography, Link, ButtonGroup, Button, CircularProgress } from "@mui/material";
 
 import { useContractKit } from "@celo-tools/use-contractkit";
 import { useEffect, useState } from "react";
@@ -7,44 +7,90 @@ import { truncateAddress } from "@/utils";
 
 import redstone from "redstone-api"
 
+async function getPrices() {
+  return {
+    CELO: await redstone.getPrice("CELO"),
+    EUR: await redstone.getPrice("EUR"),
+    ETH: await redstone.getPrice("ETH")
+  };
+}
+
+enum BaseCurrency {
+  USD = "USD",
+  EUR = "EUR",
+  ETH = "ETH",
+  CELO = "CELO"
+}
+
+function formatValue(value: number, currency: BaseCurrency): string {
+  if (currency === BaseCurrency.USD) return `$${value}`;
+  if (currency === BaseCurrency.EUR) return `€${value}`;
+  if (currency === BaseCurrency.ETH) return `${value} ETH`;
+  return `${value} CELO`;
+}
+
 export function AccountInfo() {
   const { kit, address, network } = useContractKit();
+  const [ loadingBalance, setLoadingBalance ] = useState(true);
+  const [ baseCurrency, setBaseCurrency ] = useState(BaseCurrency.USD);
+
   const [balance, setBalance] = useState({
     CELO: {
-      raw: '0', usd: '0'
+      raw: '0', base: 0, exchange: 1
     },
     cEUR: {
-      raw: '0'
+      raw: '0', base: 0, exchange: 1
     },
     cUSD: {
+      raw: '0', base: 0, exchange: 1
+    },
+    cREAL: {
       raw: '0'
     }
   });
 
   async function fetchBalance() {
-    const { CELO, cUSD, cEUR } = await kit.getTotalBalance(address);
+    const { CELO, cUSD, cEUR, cREAL } = await kit.getTotalBalance(address);
     const celoAmount = kit.web3.utils.fromWei(CELO.toString(), 'ether');
-    const celoUsdPrice = await redstone.getPrice('CELO');
+    const ceurAmount = kit.web3.utils.fromWei(cEUR.toString(), 'ether');
+    const cusdAmount = kit.web3.utils.fromWei(cUSD.toString(), 'ether');
+    const { CELO: celoUsdPrice, EUR: eurUsdPrice, ETH: ethUsdPrice } = await getPrices();
+    const scale = (
+      baseCurrency === BaseCurrency.USD
+        ? 1 : baseCurrency === BaseCurrency.EUR
+        ? 1.0 / eurUsdPrice.value : baseCurrency === BaseCurrency.ETH
+        ? 1.0 / ethUsdPrice.value : 1.0 / celoUsdPrice.value
+    );
 
     setBalance({
       CELO: {
         raw: kit.web3.utils.fromWei(CELO.toString(), 'ether'),
-        usd: (celoUsdPrice.value * (+celoAmount)).toString()
+        base: (celoUsdPrice.value * (+celoAmount) * scale),
+        exchange: celoUsdPrice.value * scale
       },
       cEUR: {
-        raw: kit.web3.utils.fromWei(cUSD.toString(), 'ether'),
+        raw: kit.web3.utils.fromWei(cEUR.toString(), 'ether'),
+        base: (eurUsdPrice.value * (+ceurAmount) * scale),
+        exchange: eurUsdPrice.value * scale
       },
       cUSD: {
-        raw: kit.web3.utils.fromWei(cEUR.toString(), 'ether'),
+        raw: kit.web3.utils.fromWei(cUSD.toString(), 'ether'),
+        base: (+cusdAmount * scale),
+        exchange: scale
+      },
+      cREAL: {
+        raw: kit.web3.utils.fromWei(cREAL.toString(), 'ether'),
       }
     })
+    setLoadingBalance(false)
   }
 
   useEffect(() => {
     if (address) {
+      setLoadingBalance(true)
       fetchBalance()
     }
-  }, [network, address])
+  }, [network, address, baseCurrency])
 
   const addressLink = `${network.explorer}/address/${address}`
 
@@ -60,11 +106,27 @@ export function AccountInfo() {
         <Divider sx={{ m: 1 }} />
         <Typography variant="h6">Balance:</Typography>
         <Typography sx={{ m: 1, marginLeft: 0, wordWrap: "break-word" }}>
-          {`${balance.CELO.raw} CELO ($${balance.CELO.usd})`}
-          <br />
-          {`${balance.cUSD.raw} cUSD`}
-          <br />
-          {`${balance.cEUR.raw} cEUR`}
+          { loadingBalance ? <CircularProgress /> : (
+            <>
+              {`${balance.CELO.raw} CELO (${formatValue(balance.CELO.base, baseCurrency)} @ ${formatValue(balance.CELO.exchange, baseCurrency)}/CELO)`}
+              <br />
+              {`${balance.cUSD.raw} cUSD (${formatValue(balance.cUSD.base, baseCurrency)} @ ${formatValue(balance.cUSD.exchange, baseCurrency)}/cUSD)`}
+              <br />
+              {`${balance.cEUR.raw} cEUR (${formatValue(balance.cEUR.base, baseCurrency)} @ ${formatValue(balance.cEUR.exchange, baseCurrency)}/cEUR)`}
+              <br />
+              {`${balance.cREAL.raw} cREAL (value estimate not supported)`}
+            </>
+          )}
+        </Typography>
+        <ButtonGroup variant="outlined" aria-label="outlined primary button group">
+          { [ BaseCurrency.USD, BaseCurrency.EUR, BaseCurrency.ETH, BaseCurrency.CELO ].map(currency => (
+            <Button key={currency} onClick={() => setBaseCurrency(currency)} variant={currency === baseCurrency ? "contained" : undefined}>
+              {currency}
+            </Button>
+          )) }
+        </ButtonGroup>
+        <Typography sx={{ m: 1, marginLeft: 0, wordWrap: "break-word", fontSize: "0.7em" }}>
+          * Value estimates from <a href="https://github.com/redstone-finance/redstone-api">Redstone API</a>. Actual values may vary slightly.
         </Typography>
       </Grid>
     </Grid>

--- a/packages/react-app/components/AccountInfo.tsx
+++ b/packages/react-app/components/AccountInfo.tsx
@@ -7,26 +7,14 @@ import { truncateAddress } from "@/utils";
 
 import redstone from "redstone-api"
 
+import AccountTable, { BaseCurrency } from './AccountTable';
+
 async function getPrices() {
   return {
     CELO: await redstone.getPrice("CELO"),
     EUR: await redstone.getPrice("EUR"),
     ETH: await redstone.getPrice("ETH")
   };
-}
-
-enum BaseCurrency {
-  USD = "USD",
-  EUR = "EUR",
-  ETH = "ETH",
-  CELO = "CELO"
-}
-
-function formatValue(value: number, currency: BaseCurrency): string {
-  if (currency === BaseCurrency.USD) return `$${value}`;
-  if (currency === BaseCurrency.EUR) return `€${value}`;
-  if (currency === BaseCurrency.ETH) return `${value} ETH`;
-  return `${value} CELO`;
 }
 
 export function AccountInfo() {
@@ -107,17 +95,16 @@ export function AccountInfo() {
         <Typography variant="h6">Balance:</Typography>
         <Typography sx={{ m: 1, marginLeft: 0, wordWrap: "break-word" }}>
           { loadingBalance ? <CircularProgress /> : (
-            <>
-              {`${balance.CELO.raw} CELO (${formatValue(balance.CELO.base, baseCurrency)} @ ${formatValue(balance.CELO.exchange, baseCurrency)}/CELO)`}
-              <br />
-              {`${balance.cUSD.raw} cUSD (${formatValue(balance.cUSD.base, baseCurrency)} @ ${formatValue(balance.cUSD.exchange, baseCurrency)}/cUSD)`}
-              <br />
-              {`${balance.cEUR.raw} cEUR (${formatValue(balance.cEUR.base, baseCurrency)} @ ${formatValue(balance.cEUR.exchange, baseCurrency)}/cEUR)`}
-              <br />
-              {`${balance.cREAL.raw} cREAL (value estimate not supported)`}
-            </>
+              <AccountTable
+                  rows={[
+                      { token: BaseCurrency.CELO, balance: +balance.CELO.raw, value: +balance.CELO.base, exchange: balance.CELO.exchange, baseCurrency },
+                      { token: BaseCurrency.USD, balance: +balance.cUSD.raw, value: +balance.cUSD.base, exchange: balance.cUSD.exchange, baseCurrency },
+                      { token: BaseCurrency.EUR, balance: +balance.cEUR.raw, value: +balance.cEUR.base, exchange: balance.cEUR.exchange, baseCurrency }
+                  ]}
+              />
           )}
         </Typography>
+        <Typography variant="h6">Select base currency for display:</Typography>
         <ButtonGroup variant="outlined" aria-label="outlined primary button group">
           { [ BaseCurrency.USD, BaseCurrency.EUR, BaseCurrency.ETH, BaseCurrency.CELO ].map(currency => (
             <Button key={currency} onClick={() => setBaseCurrency(currency)} variant={currency === baseCurrency ? "contained" : undefined}>

--- a/packages/react-app/components/AccountTable.tsx
+++ b/packages/react-app/components/AccountTable.tsx
@@ -1,0 +1,68 @@
+import * as React from 'react';
+import Table from '@mui/material/Table';
+import TableBody from '@mui/material/TableBody';
+import TableCell from '@mui/material/TableCell';
+import TableContainer from '@mui/material/TableContainer';
+import TableHead from '@mui/material/TableHead';
+import TableRow from '@mui/material/TableRow';
+import Paper from '@mui/material/Paper';
+
+export enum BaseCurrency {
+    USD = "cUSD",
+    EUR = "cEUR",
+    ETH = "ETH",
+    CELO = "CELO"
+  }
+
+type AccountDataEntry = {
+    token: BaseCurrency;
+    balance: number;
+    value: number;
+    exchange: number;
+    baseCurrency: BaseCurrency;
+};
+
+function formatSmallValue(value: number): string {
+    if (value < 1e-8) return `${(value * 1e9).toFixed(3)} n`;
+    if (value < 1e-5) return `${(value * 1e6).toFixed(3)} μ`;
+    if (value < 1e-2) return `${(value * 1e3).toFixed(3)} m`;
+    return value.toFixed(3) + " ";
+}
+
+function formatValue(value: number, currency: BaseCurrency): string {
+    if (currency === BaseCurrency.USD) return `$${value.toFixed(2)}`;
+    if (currency === BaseCurrency.EUR) return `€${value.toFixed(2)}`;
+    if (currency === BaseCurrency.ETH) return `${value < 0.01 ? formatSmallValue(value) : value.toFixed(2) + " "}ETH`;
+    return `${value.toFixed(2)} CELO`;
+}
+
+const AccountTable: React.FC<{ rows: AccountDataEntry[] }> = ({ rows }) => (
+    <TableContainer component={Paper}>
+      <Table sx={{ minWidth: 650 }} aria-label="simple table">
+        <TableHead>
+          <TableRow>
+            <TableCell>Token</TableCell>
+            <TableCell align="right">Balance</TableCell>
+            <TableCell align="right">Estimated Value</TableCell>
+            <TableCell align="right">Estimated Exchange</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          { rows.map((row) => (
+            <TableRow
+              key={row.token}
+              sx={{ '&:last-child td, &:last-child th': { border: 0 } }}
+            >
+              <TableCell component="th" scope="row">
+                {row.token}
+              </TableCell>
+              <TableCell align="right">{row.balance < 0.01 ? row.balance.toExponential(2) : row.balance.toFixed(2)} {row.token}</TableCell>
+              <TableCell align="right">{formatValue(row.value, row.baseCurrency)}</TableCell>
+              <TableCell align="right">{formatValue(row.exchange, row.baseCurrency)} / {row.token}</TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </TableContainer>
+);
+export default AccountTable;

--- a/packages/react-app/components/AccountTable.tsx
+++ b/packages/react-app/components/AccountTable.tsx
@@ -56,7 +56,7 @@ const AccountTable: React.FC<{ rows: AccountDataEntry[] }> = ({ rows }) => (
               <TableCell component="th" scope="row">
                 {row.token}
               </TableCell>
-              <TableCell align="right">{row.balance < 0.01 ? row.balance.toExponential(2) : row.balance.toFixed(2)} {row.token}</TableCell>
+              <TableCell align="right">{row.balance < 0.01 ? formatSmallValue(row.balance) : row.balance.toFixed(2) + " "}{row.token}</TableCell>
               <TableCell align="right">{formatValue(row.value, row.baseCurrency)}</TableCell>
               <TableCell align="right">{formatValue(row.exchange, row.baseCurrency)} / {row.token}</TableCell>
             </TableRow>

--- a/packages/react-app/components/GreeterContract.tsx
+++ b/packages/react-app/components/GreeterContract.tsx
@@ -4,7 +4,7 @@ import { Box, Button, Divider, Grid, Typography, Link } from "@mui/material";
 import { useInput } from "@/hooks/useInput";
 import { useContractKit } from "@celo-tools/use-contractkit";
 import { useEffect, useState } from "react";
-import { useSnackbar } from "notistack";
+import { SnackbarAction, SnackbarKey, useSnackbar } from "notistack";
 import { truncateAddress } from "@/utils";
 import { Greeter } from "@celo-progressive-dapp-starter/hardhat/types/Greeter";
 
@@ -44,7 +44,7 @@ export function GreeterContract({ contractData }) {
 
         const variant = result.status == true ? "success" : "error";
         const url = `${network.explorer}/tx/${result.transactionHash}`;
-        const action = (key) => (
+        const action: SnackbarAction = (key) => (
           <>
             <Link href={url} target="_blank">
               View in Explorer


### PR DESCRIPTION
this adds the ability to toggle between base currencies on the balance page (ETH, USD, EUR, and CELO), see token balances denominated in the base currency, and see current price estimates for tokens in the base currency